### PR TITLE
use run based (old) calculation in prod env

### DIFF
--- a/radixconfig.yaml
+++ b/radixconfig.yaml
@@ -54,3 +54,4 @@ spec:
           variables:
             PIPELINE_IMG_TAG: "release-latest"
             LOG_LEVEL: INFO
+            USE_RUN_COST_SERVICE: true


### PR DESCRIPTION
We need to use the old "run" and "required_resource" based cost calculation for a month or so. The new container based calculation needs some time to gather enough data for correct calculation of cost.