### PR TITLE
use 'from scratch' to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,9 +40,10 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-s -w" -a -installsuffix cgo -o 
 RUN addgroup -S -g 1000 radix-cost
 RUN adduser -S -u 1000 -G radix-cost radix-cost
 
-#FROM scratch
-#COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-#COPY --from=builder /usr/local/bin/radix-cost-allocation-api /usr/local/bin/radix-cost-allocation-api
+FROM scratch
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /usr/local/bin/radix-cost-allocation-api /usr/local/bin/radix-cost-allocation-api
+COPY --from=builder /etc/passwd /etc/passwd
 USER 1000
 EXPOSE 3003
 ENTRYPOINT ["/usr/local/bin/radix-cost-allocation-api"]


### PR DESCRIPTION
Without 'from scratch' tghe image size is 1.6GB.
Using scratch reduce size to 19MB