### PR TITLE
fix: set currency if missing when enumerating containers to build application cost

### DIFF
--- a/service/costservice_containerimpl.go
+++ b/service/costservice_containerimpl.go
@@ -130,6 +130,10 @@ func buildApplicationCostList(containerTotalCostList []containerTotalCost) []mod
 			appCostIndex[c.container.ApplicationName] = len(applicationCostList) - 1
 			wbsCodes[c.container.ApplicationName] = c.container.LastKnownRunningAt
 		} else {
+			if len(applicationCostList[idx].Currency) == 0 {
+				applicationCostList[idx].Currency = c.currency
+			}
+
 			applicationCostList[idx].Cost += c.value
 
 			if c.container.LastKnownRunningAt.After(wbsCodes[c.container.ApplicationName]) {
@@ -391,10 +395,11 @@ func isCostEncapsulated(first, second models.NodePoolCostDto) bool {
 
 // NodePoolCostDto sorter - sorts by FromDate, and for entries where FromDate is equal we sort by ToDate
 // Example entries
-//   |---------|
-//        |-------|
-//        |----------------|
-//             |----|
+//
+//	|---------|
+//	     |-------|
+//	     |----------------|
+//	          |----|
 type sortByFromAndTo []models.NodePoolCostDto
 
 func (c sortByFromAndTo) Len() int { return len(c) }


### PR DESCRIPTION
This PR fixes a bug where only the currency of the first container is used when aggregating cost for an application. If this container happens to be for a node on a nodepool that does not have any cost registered, the currency is set to an empty string, since the container does not have a cost or currency set. Containers on nodepools without cost will have cost and currency set to 0.

The fix will set currency if empty when enumerating container cost to aggregate application cost.
